### PR TITLE
Move serialize function to utils

### DIFF
--- a/src/quoalise/__main__.py
+++ b/src/quoalise/__main__.py
@@ -7,8 +7,7 @@ from xml.dom import minidom
 import xml.etree.ElementTree as ET
 
 from .client import Client
-from .utils import parse_iso_date
-from .data import Record
+from .utils import parse_iso_date, serialize
 from .errors import NotAuthorized, ServiceUnavailable
 
 
@@ -91,13 +90,6 @@ def get_records(
         print(minidom.parseString(ET.tostring(data.xml)).toprettyxml(indent="  "))
 
     elif format == "json":
-
-        def serialize(obj):
-            if isinstance(obj, (dt.datetime, dt.date)):
-                return obj.isoformat()
-            if isinstance(obj, Record):
-                return obj.__dict__
-            return str(obj)
 
         print(
             json.dumps(

--- a/src/quoalise/utils.py
+++ b/src/quoalise/utils.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from .data import Record
 
 
 def parse_iso_date(date_str):
@@ -7,3 +8,11 @@ def parse_iso_date(date_str):
 
 def format_iso_date(date):
     return date.strftime("%Y-%m-%d")
+
+
+def serialize(obj):
+    if isinstance(obj, (dt.datetime, dt.date)):
+        return obj.isoformat()
+    if isinstance(obj, Record):
+        return obj.__dict__
+    return str(obj)


### PR DESCRIPTION
La fonction `serialize` est aujourd'hui définie dans `__main__.py`  mais peut être utilisée si on utilise directement la classe `Client` sans passer par le cli (ce qui est mon cas). 

Je propose de la déplacer dans `utils`.

Peut-être qu'il conviendra de la renommer car `serialize` est très générique hors contexte.